### PR TITLE
Update CODE_OF_CONDUCT-fr.md

### DIFF
--- a/docs/CODE_OF_CONDUCT-fr.md
+++ b/docs/CODE_OF_CONDUCT-fr.md
@@ -44,7 +44,7 @@ Les instances de comportement abusif, harcelant ou autrement inacceptable
 peuvent être signalés en contactant un responsable de projet à
 victorfelder at gmail.com. Toutes les plaintes seront examinées et étudiées
 et se traduiront par une réponse jugée nécessaire et appropriée aux
-circonstances. Les mainteneurs s'obligent à garder confidentielles les
+circonstances. Les mainteneurs s'engagent à garder confidentielles les
 informations de la personne qui remonte un incident.
 
 Ce Code de Conduite est adaptée du [Contributor Covenant][homepage],


### PR DESCRIPTION
In the sentence "Les mainteneurs s'obligent à garder confidentielles les informations de la personne qui remonte un incident," the word "obligent" should be "engagent" to match the subject: "Les mainteneurs s'engagent à garder confidentielles les informations de la personne qui remonte un incident".

## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo

## For resources
### Description

### Why is this valuable (or not)?

### How do we know it's really free?

### For book lists, is it a book? For course lists, is it a course? etc.

## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [ ] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction).
- [ ] Used an informative name for this pull request.

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
